### PR TITLE
Unpack and strictify parser state

### DIFF
--- a/comark-parser/src/Comark/ParserCombinators/Prim.hs
+++ b/comark-parser/src/Comark/ParserCombinators/Prim.hs
@@ -40,9 +40,9 @@ import           Prelude             hiding (takeWhile)
 
 data Position
   = Position
-      { line   :: Int
-      , column :: Int
-      , point  :: Int
+      { line   :: {-# UNPACK #-} !Int
+      , column :: {-# UNPACK #-} !Int
+      , point  :: {-# UNPACK #-} !Int
       } deriving (Ord, Eq)
 
 instance Show Position where
@@ -57,9 +57,9 @@ data ParseError
 
 data ParserState
   = ParserState
-      { subject  :: Text
-      , position :: Position
-      , lastChar :: Maybe Char
+      { subject  :: {-# UNPACK #-} !Text
+      , position :: {-# UNPACK #-} !Position
+      , lastChar :: !(Maybe Char)
       }
 
 advance :: ParserState -> Text -> ParserState


### PR DESCRIPTION
This seems to improve overall performance, degree of improvement varies depending on the "tightness" of inputs. Progit benchmark became 1.5-2x faster, various microbenchmarks improved 2-3x, 30x improvement for nested-parenths pathology.